### PR TITLE
Environment var configurables

### DIFF
--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -1,5 +1,5 @@
 # sets global address name
-  resource "google_compute_global_address" "default" {
+resource "google_compute_global_address" "default" {
   project = local.deployment_project
   name    = var.application_name
 }

--- a/main.tf
+++ b/main.tf
@@ -42,15 +42,15 @@ resource "google_cloud_run_service" "default" {
         }
         env {
           name  = "ACTIVATION_TIMEOUT"
-          value = "60"
+          value = var.maximum_duration
         }
         env {
           name  = "JUSTIFICATION_HINT"
-          value = "Bug or case number"
+          value = var.justification_hint
         }
         env {
           name  = "JUSTIFICATION_PATTERN"
-          value = ".*"
+          value = var.justification_pattern
         }
         env {
           name  = "IAP_BACKEND_SERVICE_ID"

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,24 @@ variable "allow_unauthenticated_invocations" {
   default     = false
 }
 
+variable "maximum_duration" {
+  type        = number
+  description = "Sets the longest duration that a user can request"
+  default     = 60
+}
+
+variable "justification_hint" {
+  type        = string
+  description = "Hint provided to the user when selecting why they are asking for the role"
+  default     = "Bug or case number"
+}
+
+variable "justification_pattern" {
+  type        = string
+  description = "Regex pattern that justification must match"
+  default     = ".*"
+}
+
 ## Scope Variables
 variable "scope_type" {
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "hashicorp/google-beta"
       version = "~> 4"
     }
+    random = {
+      source = "hashicorp/random"
+      version = "~> 3"
+    }
   }
 }


### PR DESCRIPTION
## Background

Add support to set the environment variable configurables in the application.

- **ACTIVATION_TIMEOUT** - Allows you to set the maximum length of time a user can request  a Role. 
- **JUSTIFICATION_HINT** - Allows you to set the hit provided to the user when justifying the request.
- **JUSTIFICATION_PATTERN** - Allows you to limit using regex the patterns users can put in the hint.

This allows you to set the matching variables via inputs to the module.
The only change I have made is to use `maximum_duration` for ACTIVATION_TIMEOUT as this is how its worded at the input screen and makes it easier to understand imo

